### PR TITLE
Run more expensive CI steps in a 2nd stage, check dependencies

### DIFF
--- a/.github/workflows/check_quality.yml
+++ b/.github/workflows/check_quality.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2024 Siemens AG
+# SPDX-FileCopyrightText: Copyright 2025 Siemens AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -14,6 +14,8 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Stage 1: fast and basic checks, we run them in parallel to provide more feedback to the contributor at once,
+  # instead of running them sequentially and giving feedback one piece at a time, requiring more iterations.
   ruff_lint:
     runs-on: ubuntu-22.04
     container:
@@ -57,7 +59,32 @@ jobs:
       - name: Spelling checker
         run: codespell . --check-filenames --skip *.html,*.pem,*.xml,*venv*,*fips/*.py
 
+  dependency_check:
+    # See if newer versions of our Python dependencies are available. This does
+    # not enforce anything, and only has an informational character.
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/cmp-test-dev:latest
+    steps:
+      - name: Check for outdated dependencies
+        run: |
+          echo "Checking for outdated packages..."
+          OUTDATED=$(pip list --outdated --format=columns)
+          if [ -z "$OUTDATED" ]; then
+            echo "All packages are up to date!"
+            exit 0
+          else
+            echo "Outdated packages detected, think about it:"
+            echo "$OUTDATED"
+            exit 1
+          fi
+
+  # ----------------------------------------------------------------------------
+  # Stage 2: these checks are more expensive and do more with the code, e.g., attempt to import dependencies,
+  # execute some logic, etc.
   pylint:
+    needs: [ruff_lint, license_check, rf_style_check, spelling_check]
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/${{ github.repository_owner }}/cmp-test-dev:latest
@@ -68,6 +95,7 @@ jobs:
         run: pylint --fail-under=9.4 resources
 
   unit_test:
+    needs: [ruff_lint, license_check, rf_style_check, spelling_check]
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/${{ github.repository_owner }}/cmp-test-dev:latest
@@ -79,13 +107,15 @@ jobs:
       - name: Unit tests
         run: PYTHONPATH=./resources python3 -m unittest discover -s unit_tests
 
-  # type_check:
-  #   runs-on: ubuntu-22.04
-  #   container:
-  #     image: ghcr.io/${{ github.repository_owner }}/cmp-test-dev:latest
+  type_check:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/cmp-test-dev:latest
 
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #     - name: Pyright check
-  #       run: PYTHONPATH=./resources pyright ./resources
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Pyright check
+        run: PYTHONPATH=./resources pyright ./resources
+    # not enforced yet, but it is still executed to provide some info
+    continue-on-error: true


### PR DESCRIPTION
Minor tweaks in the CI pipeline

- Break it down into several stages, one for "cheap" checks and another for "expensive" ones
- The jobs within each stage still run in parallel, since we prioritize providing feedback rather than saving CPU cycles
- Added a new job that lists outdated dependencies, if any; it only has an informational character and won't stop you from merging the new code, its sole purpose is to make you aware of newer versions.