### PR TITLE
Update Docker base OS to Ubuntu 25:10

### DIFF
--- a/data/dockerfiles/Dockerfile.base
+++ b/data/dockerfiles/Dockerfile.base
@@ -4,7 +4,7 @@
 # To experiment locally, build it with:
 # `docker build -t cmptest-base -f data/dockerfiles/Dockerfile.base .`
 
-FROM ubuntu:22.04
+FROM ubuntu:25.10
 
 RUN apt-get update && \
     apt-get install -y python3 python3-pip python3-venv openssl libssl-dev cmake git build-essential ca-certificates && \


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Update the Docker FORM OS to Ubuntu:25:10

## Description

- Updates the OpenSSL version to a release above 3.5 to enable PQC algorithm support.

## Motivation and Context

- Enables integration and testing of PQC client test cases.

## How Has This Been Tested?

- Verified through the CI pipeline, including build and quality checks.
 
