### PR TITLE
Fix `PasswordRecipientInfo` version to be 3 (Errata ID: 7833)

### DIFF
--- a/resources/ca_kga_logic.py
+++ b/resources/ca_kga_logic.py
@@ -1560,7 +1560,7 @@ def validate_password_recipient_info(pwri_structure: rfc5652.PasswordRecipientIn
                                 which must not be reused here.
     :return: A dictionary containing the PBKDF2 parameters (`parameters`) and the encrypted key (`encrypted_key`).
     :raises ValueError: If any of the following conditions are violated:
-        The `version` field is missing or not equal to `0`.
+        The `version` field is missing or not equal to `3`.
         The `keyDerivationAlgorithm` field is missing or not one of the allowed algorithms.
         The `keyEncryptionAlgorithm` field is missing or not one of the allowed algorithms.
         The `encryptedKey` field is missing.
@@ -1570,8 +1570,9 @@ def validate_password_recipient_info(pwri_structure: rfc5652.PasswordRecipientIn
             The AES key wrap `parameters` field is present (must be absent).
     """
     if pwri_structure["version"].isValue:
-        if int(pwri_structure["version"]) != 0:
-            raise ValueError("The `version` field of the `PasswordRecipientInfo` structure must be 0!")
+        # According to RFC9483 Errata ID: 7833, must the `PasswordRecipientInfo` version be 3.
+        if int(pwri_structure["version"]) != 3:
+            raise ValueError("The `version` field of the `PasswordRecipientInfo` structure must be 3!")
     else:
         raise ValueError("The `version` field of the `PasswordRecipientInfo` structure was absent!")
 

--- a/resources/envdatautils.py
+++ b/resources/envdatautils.py
@@ -2014,7 +2014,7 @@ def _prepare_aes_warp_alg_id(
 @keyword(name="Prepare PasswordRecipientInfo")
 def prepare_password_recipient_info(  # noqa D417 undocumented-param
     password: Union[str, bytes],
-    version: Union[str, int] = 0,
+    version: Union[str, int] = 3,
     cek: Optional[bytes] = None,
     kdf_name: str = "pbkdf2",
     bad_encrypted_key: bool = False,
@@ -2030,7 +2030,7 @@ def prepare_password_recipient_info(  # noqa D417 undocumented-param
     Arguments:
     ---------
         - `password`: The password to use for encryption.
-        - `version`: The version number for the `PasswordRecipientInfo` structure. Defaults to `0`.
+        - `version`: The version number for the `PasswordRecipientInfo` structure. Defaults to `3`.
         - `cek`: The content encryption key to encrypt. Defaults to a random 32-byte key.
         - `kdf_name`: The key derivation function to use. Defaults to "pbkdf2".
         (which is the only one allowed for `PasswordRecipientInfo`).

--- a/unit_tests/tests_protocol_related/test_kga_logic/test_kga_pwri.py
+++ b/unit_tests/tests_protocol_related/test_kga_logic/test_kga_pwri.py
@@ -36,9 +36,9 @@ class TestValidationPWRI(unittest.TestCase):
 
     def test_pwri_invalid_version(self):
         """
-        GIVEN a PWRI structure with an invalid version (not 0).
+        GIVEN a PWRI structure with an invalid version (not 3).
         WHEN validate_password_recipient_info is called.
-        THEN it should raise a ValueError indicating the version field must be 0.
+        THEN it should raise a ValueError indicating the version field must be 3.
         """
         pwri = prepare_pwri_structure(version=1)
 

--- a/unit_tests/utils_for_test.py
+++ b/unit_tests/utils_for_test.py
@@ -1128,7 +1128,7 @@ def _prepare_pbkdf2() -> rfc8018.PBKDF2_params:
 
 @not_keyword
 def prepare_pwri_structure(
-    version: int = 0,
+    version: int = 3,
     kdf_oid: univ.ObjectIdentifier = rfc9481.id_PBKDF2,
     key_enc_alg_id: univ.ObjectIdentifier = rfc9481.id_aes256_wrap,
     enc_key: bool = True,
@@ -1139,7 +1139,7 @@ def prepare_pwri_structure(
 
     Prepares a default `PBKDF2_params` structure with the fixed salt b"AAAAAAAAAAAAAAAA".
 
-    :param version: The version number for the `PasswordRecipientInfo` structure. Defaults to 0.
+    :param version: The version number for the `PasswordRecipientInfo` structure. Defaults to 3.
     :param kdf_oid: The Object Identifier (OID) for the key derivation algorithm.
     :param key_enc_alg_id: The OID for the key encryption algorithm.
     :param enc_key:  Flag indicating whether to include the encrypted key in the `PasswordRecipientInfo`.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Fix incorrect version for the PasswordRecipientInfo.

## Description
* Updated the `PasswordRecipientInfo` default value to 3 to conform to RFC9483 Errata ID: 7833. This ensures correctness and consistency across implementations. 
* Updated the unit tests.

## Motivation and Context

- Correct implementation.

## How Has This Been Tested?

- Unit tests were updated and executed to validate the correct behavior. 
- The RF tests were run against the MockCA.