### PR TITLE
Clean Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ help:
 	@echo  'Commands:'
 	@echo  '  test         - Run all compliance tests (results will be in reports/)'
 	@echo  '  test-verbose - Run all compliance tests, including verbose tests (results will be in reports/)'
+	@echo  '  test-pq-hybrid         - Run all PQ and Hybrid compliance tests (results will be in reports/)'
+	@echo  '  test-pq-hybrid-verbose - Run all PQ and Hybrid compliance tests, including verbose tests (results will be in reports/)'
 	@echo  '  teslog       - Run all compliance tests, store results in timestamped subirectories in reports/'
 	@echo  '  docs          - Produce documentation files and store them in doc/'
 	@echo  '  unittest     - Run unit tests for the test suite itself '


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Clean and fix the Makefile documentation. Fixed the Docker-based unit testing. Also add spell-checking step to the verification process and removed irrelevant commands.


## Description


* Added new commands to the help section documentation: `test-pq-hybrid`,  `test-pq-hybrid-verbose` and `dryrun`.

* Changed the Dockerfile used for building the unittest image from `Dockerfile.unittest` to `Dockerfile.base`, and updated the `unittest-docker` target to mount the current directory and run Python unit tests inside the container.

* Added the `codespell` step to the `verify` target to check for spelling errors in code and filenames, skipping specified files and directories.

* Removed irrelevant commands: `stats` and `invalid-sig`.

## Motivation and Context

- Have a working `unittest-docker` command.
- Add missing documentation for commands (better usage).
- Removed irrelevant commands.

## How Has This Been Tested?
Locally tested 
 
