### PR TITLE
Fix: P10CR `certReqId` Handling per RFC Errata 8806

### DIFF
--- a/SERVER_TEST_COVERAGE.md
+++ b/SERVER_TEST_COVERAGE.md
@@ -247,14 +247,15 @@ Each entry below represents a template that expands to multiple Robot‑Framewor
 
 ## Section 4.1.4
 
-| Test Case                                                                    | File        |
-| ---------------------------------------------------------------------------- | ----------- |
-| CA MUST Issue A Certificate Upon Receiving A Valid P10CR                     | basic.robot |
-| CA MUST Reject Request With Invalid CSR Signature                            | basic.robot |
-| CA MUST Issue A Valid Certificate Upon Receiving A Valid MAC-Protected P10CR | basic.robot |
-| CA MUST Issue A Valid Certificate Upon Receiving A Valid SIG-Protected P10CR | basic.robot |
-| CA MUST Issue Certificate Via P10CR Without ImplicitConfirm                  | lwcmp.robot |
-| CA MUST Send A Valid CP After Receiving Valid P10CR                          | basic.robot |
+| Test Case                                                                    | File                  |
+| ---------------------------------------------------------------------------- |-----------------------|
+| CA MUST Issue A Certificate Upon Receiving A Valid P10CR                     | basic.robot           |
+| CA MUST Reject Request With Invalid CSR Signature                            | basic.robot           |
+| CA MUST Issue A Valid Certificate Upon Receiving A Valid MAC-Protected P10CR | basic.robot           |
+| CA MUST Issue A Valid Certificate Upon Receiving A Valid SIG-Protected P10CR | basic.robot           |
+| CA MUST Issue Certificate Via P10CR Without ImplicitConfirm                  | lwcmp.robot           |
+| CA MUST Send A Valid CP After Receiving Valid P10CR                          | basic.robot           |
+| CA MUST Reject certConf For P10cr With certReqId Set To Zero                 | cert_conf_tests.robot |
 
 ### Section 4.1.5 MAC-Based Enrollment
 

--- a/mock_ca/cert_conf_handler.py
+++ b/mock_ca/cert_conf_handler.py
@@ -351,6 +351,8 @@ class CertConfHandler:
             allow_failure_sender=False,
             time_interval=None,
         )
+        request = self.conf_state.get_request(pki_message)
+        was_p10cr = get_cmp_message_type(request) == "p10cr"
 
         issued_certs = self.conf_state.get_confirmable_certs(pki_message)
 
@@ -361,6 +363,7 @@ class CertConfHandler:
             request=pki_message,
             issued_certs=issued_certs,
             allow_auto_ed=self.config_vars.allow_auto_ed,
+            was_p10cr=was_p10cr,
         )
 
         requests = self.conf_state.get_request(pki_message)

--- a/resources/ca_ra_utils.py
+++ b/resources/ca_ra_utils.py
@@ -3236,8 +3236,14 @@ def build_pki_conf_from_cert_conf(  # noqa: D417 Missing argument descriptions i
     entry: rfc9480.CertStatus
     hash_alg = kwargs.get("hash_alg")
     for entry, issued_cert in zip(cert_conf, issued_certs):
-        if entry["certReqId"] != 0 and enforce_lwcmp:
-            raise BadRequest(f"Invalid CertReqId in CertConf message. Got: {int(entry['certReqId'])}Expected: 0.")
+        if kwargs.get("was_p10cr"):
+            if int(entry["certReqId"]) != -1:
+                raise BadRequest(
+                    f"Invalid CertReqId in CertConf message for p10cr. Got: {int(entry['certReqId'])} Expected: -1."
+                )
+
+        elif entry["certReqId"] != 0 and enforce_lwcmp:
+            raise BadRequest(f"Invalid CertReqId in CertConf message. Got: {int(entry['certReqId'])} Expected: 0.")
 
         if not entry["certHash"].isValue:
             raise BadPOP("Certificate hash is missing in CertConf message.")

--- a/resources/cmputils.py
+++ b/resources/cmputils.py
@@ -3385,7 +3385,6 @@ def _process_single_cert_conf_cert(
 
 def _get_cert_req_id(
     cert_resp: rfc9480.CertResponse,
-    length: int = 0,
     cert_req_id: Optional[Strint] = None,
 ) -> Strint:
     """Get the certificate request ID from the response message.
@@ -3394,9 +3393,6 @@ def _get_cert_req_id(
     :param length: The length of the certificate request ID. Defaults to `0`.
     :param cert_req_id: The certificate request ID to use. If not provided, it will be extracted from the response.
     """
-    if length == 1 and cert_req_id is None:
-        # To fix for `p10cr` response were the certReqId is `-1`.
-        return max(int(cert_resp["certReqId"]), 0)
     return int(cert_req_id) if cert_req_id is not None else int(cert_resp["certReqId"])
 
 
@@ -3535,7 +3531,6 @@ def build_cert_conf_from_resp(  # noqa D417 undocumented-param
         for i, entry in enumerate(cert_resp_msg):
             cert_req_id = _get_cert_req_id(
                 cert_resp=entry,
-                length=len(cert_resp_msg),
                 cert_req_id=cert_req_id,
             )
             # remove the tagging

--- a/resources/cmputils.py
+++ b/resources/cmputils.py
@@ -3533,13 +3533,12 @@ def build_cert_conf_from_resp(  # noqa D417 undocumented-param
         entry: rfc9480.CertResponse
         cert_chain = certutils.build_cmp_chain_from_pkimessage(ca_message, for_issued_cert=True)
         for i, entry in enumerate(cert_resp_msg):
-            # remove the tagging.
             cert_req_id = _get_cert_req_id(
                 cert_resp=entry,
                 length=len(cert_resp_msg),
                 cert_req_id=cert_req_id,
             )
-
+            # remove the tagging
             tmp_cert = get_cert_from_pkimessage(ca_message, cert_number=i)
 
             cert_status = _process_single_cert_conf_cert(

--- a/tests/cert_conf_tests.robot
+++ b/tests/cert_conf_tests.robot
@@ -121,6 +121,33 @@ CA MUST Reject Invalid certReqId Inside The certConf
     PKIMessage Body Type Must Be    ${response}    error
     PKIStatusInfo Failinfo Bit Must Be    ${response}    failinfo=badRequest    exclusive=True
 
+CA MUST Reject certConf For P10cr With certReqId Set To Zero
+    [Documentation]    According to RFC 9483 Section 4.1.4 and Errata 8806, certificate confirmation for
+    ...    a p10cr transaction uses certReqId -1. We send a valid p10cr request, then a certConf with
+    ...    certReqId set to 0. The CA MUST reject the confirmation and respond with an error, optionally
+    ...    including the failInfo `badRequest`.
+    [Tags]    p10cr    negative    certReqId
+    ${cm}=  Get Next Common Name
+    ${key}=     Generate Default Key
+    ${p10cr}=    Build P10cr From Key
+    ...    key=${key}
+    ...    common_name=${cm}
+    ...    sender=${SENDER}
+    ...    recipient=${RECIPIENT}
+    ${protected_p10cr}=    Default Protect PKIMessage    ${p10cr}
+    ${response}=   Exchange PKIMessage    ${protected_p10cr}
+    PKIMessage Body Type Must Be    ${response}    cp
+    PKIStatus Must Be    ${response}  accepted
+    ${cert_conf}=    Build Cert Conf From Resp
+    ...    ${response}
+    ...    sender=${SENDER}
+    ...    recipient=${RECIPIENT}
+    ...    cert_req_id=0
+    ${protected_cert_conf}=    Default Protect PKIMessage   ${cert_conf}
+    ${error_resp}=   Exchange PKIMessage    ${protected_cert_conf}
+    PKIMessage Body Type Must Be    ${error_resp}    error
+    PKIStatus Must Be    ${error_resp}    rejection
+
 CA MUST Reject failInfo With Status Accepted Inside The certConf
     [Documentation]    According to RFC 9483 Section 4.1, the certConf message must have a consistent `status`
     ...    and failInfo. A `status` "accepted" indicates no error, making the inclusion of a failInfo

--- a/tests/lwcmp.robot
+++ b/tests/lwcmp.robot
@@ -59,9 +59,9 @@ CA Must Issue Certificate Via P10cr Without implicitConfirm
     PKIMessage Body Type Must Be    ${response}    cp
     PKIStatus Must Be    ${response}  accepted
     # prepare confirmation message by extracting the certificate and getting the needed
-    # data from it cert_req_id must be also `0` for P10cr.
+    # data from it cert_req_id must be `-1` for P10cr (RFC Errata 8806).
     ${conf_message}=   Build Cert Conf From Resp    ${response}   for_mac=True
-    ...    cert_req_id=0
+    ...    cert_req_id=-1
     ...    sender=${SENDER}
     ...    recipient=${RECIPIENT}
     ...    for_mac=True

--- a/tests/verbose_cert_request_tests.robot
+++ b/tests/verbose_cert_request_tests.robot
@@ -29,10 +29,6 @@ Build CertConf For Implicit Test
     ...                If the implicit confirmation is `True`, the confirmation will include an implicit confirmation.
     ...                If `False`, it will not include an implicit confirmation.
     [Arguments]    ${body_name}    ${response}   &{params}
-    VAR   ${cert_req_id}   ${None}
-    IF  'p10cr' in '${body_name}'
-        VAR   ${cert_req_id}   0
-    END
     ${old_cert}=   Get From Dictionary    ${params}    old_cert    ${None}
     ${old_key}=   Get From Dictionary    ${params}    old_key    ${None}
     ${for_mac}=   Get From Dictionary    ${params}    for_mac    False
@@ -41,7 +37,7 @@ Build CertConf For Implicit Test
     ELSE
         VAR   ${exclude_fields}   sender,senderKID
     END
-    ${cert_conf}=   Build Cert Conf From Resp    ${response}    cert_req_id=${cert_req_id}
+    ${cert_conf}=   Build Cert Conf From Resp    ${response}
     ...             recipient=${RECIPIENT}   for_mac=${for_mac}    exclude_fields=${exclude_fields}
     ...             sender=${SENDER}   recipient=${RECIPIENT}
     IF  'added-protection-inner' in '${body_name}'

--- a/unit_tests/tests_build_messages/test_build_cert_conf.py
+++ b/unit_tests/tests_build_messages/test_build_cert_conf.py
@@ -160,3 +160,27 @@ class TestBuildCertConf(unittest.TestCase):
         self.assertNotEqual(pki_message["header"]["senderNonce"].asOctets(), b"C" * 16)
         self.assertEqual(pki_message["header"]["transactionID"].asOctets(), b"B" * 16)
         self.assertEqual(pki_message["header"]["recipNonce"].asOctets(), b"A" * 16)
+
+    def test_build_cert_conf_from_resp_keeps_negative_cert_req_id(self):
+        """
+        GIVEN a valid certConf PKIMessage for a P10CR request.
+        WHEN the certConf PKIMessage is built,
+        THEN should the certificate confirmation message have the `certReqId` set to -1.
+        """
+        ca_message = build_ca_pki_message(cert=self.cert, cert_req_id=-1)
+        ca_message["extraCerts"].append(self.ca_cert)
+        ca_message = patch_sendernonce(ca_message, sender_nonce=b"A" * 16)
+        ca_message = patch_transaction_id(ca_message, new_id=b"B" * 16)
+        ca_message = patch_recipnonce(ca_message, recip_nonce=b"C" * 16)
+
+        pki_message = build_cert_conf_from_resp(
+            ca_message=ca_message,
+            sender=self.sender,
+            recipient=self.recipient,
+        )
+
+        self.assertEqual(int(pki_message["body"]["certConf"][0]["certReqId"]), -1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/tests_ca_ra_utils/test_build_pkiconf_from_certConf.py
+++ b/unit_tests/tests_ca_ra_utils/test_build_pkiconf_from_certConf.py
@@ -4,9 +4,9 @@
 
 import unittest
 
-from resources.ca_ra_utils import build_cp_cmp_message, build_pki_conf_from_cert_conf
+from resources.ca_ra_utils import build_cp_cmp_message, build_cp_from_p10cr, build_pki_conf_from_cert_conf
 from resources.certutils import parse_certificate
-from resources.cmputils import build_cr_from_key, build_cert_conf_from_resp, prepare_certstatus
+from resources.cmputils import build_cert_conf_from_resp, build_cr_from_key, build_p10cr_from_key, prepare_certstatus
 from resources.exceptions import BadRequest, BadCertId
 from resources.keyutils import load_private_key_from_file
 from resources.utils import load_and_decode_pem_file
@@ -123,3 +123,37 @@ class TestBuildPkiConfFromCertConf(unittest.TestCase):
                 request=cert_conf,
                 issued_certs=self.certs,
             )
+
+    def test_correct_p10cr_validation(self):
+        """
+        GIVEN a valid certificate confirmation for a P10CR request with certReqId set to -1.
+        WHEN building a pkiConf from the certificate confirmation with was_p10cr=True,
+        THEN the pkiConf is built correctly without raising an exception.
+        """
+        p10cr_request = build_p10cr_from_key(
+            key=self.comp_key,
+            pvno=3,
+        )
+        response, cert = build_cp_from_p10cr(
+            request=p10cr_request,
+            ca_key=self.ca_key,
+            ca_cert=self.ca_cert,
+        )
+        response["extraCerts"].append(self.ca_cert)
+        cert_conf = build_cert_conf_from_resp(
+            ca_message=response,
+            pvno=3,
+            hash_alg="sha256",
+            cert_req_id=-1,
+        )
+
+        pki_conf = build_pki_conf_from_cert_conf(
+            request=cert_conf,
+            issued_certs=[cert],
+            was_p10cr=True,
+        )
+        self.assertEqual(pki_conf["body"].getName(), "pkiconf")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Fixes incorrect `certReqId` handling for `p10cr` (PKCS#10 Certificate Request) flows, aligning the implementation with [RFC Errata 8806](https://www.rfc-editor.org/errata/eid8806).

According to the errata, the `certReqId` for a `p10cr` certificate confirmation PKIMessage must be `-1`, not `0`.

## Description

### New Tests

- **`tests/cert_conf_tests.robot`** — Added a negative Robot Framework test case:
  - `CA MUST Reject certConf For P10cr With certReqId Set To Zero`: Sends a valid `p10cr`, then confirms with `certReqId = 0`. The CA must reject the confirmation with an error response.

- **`unit_tests/tests_build_messages/test_build_cert_conf.py`** — Added a unit test verifying that `build_cert_conf_from_resp` correctly produces `certReqId = -1` when processing a `p10cr` response.

- **`unit_tests/tests_ca/test_build_pkiconf_from_certConf.py`** — Added a unit test `test_correct_p10cr_validation` verifying that the CA correctly validates `certReqId` in `certConf` for `p10cr` transactions.

## Motivation and Context

- Fixes issue: #61 

## How Has This Been Tested

- unit tests.
- Against the MockCA. 

 
