### PR TITLE
Fix(ASN.1): Fix HashAlg Field Position For `CertStatus`

### DIFF
--- a/resources/asn1_structures.py
+++ b/resources/asn1_structures.py
@@ -224,6 +224,26 @@ nestedMessageContent = NestedMessageContentTMP().subtype(
 )
 
 
+class CertStatus(univ.Sequence):
+    """RFC 9480-compliant CertStatus: hashAlg placed last."""
+
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType("certHash", univ.OctetString()),
+        namedtype.NamedType("certReqId", univ.Integer()),
+        namedtype.OptionalNamedType("statusInfo", rfc9480.PKIStatusInfo()),
+        namedtype.OptionalNamedType(
+            "hashAlg",
+            rfc5280.AlgorithmIdentifier().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)),
+        ),
+    )
+
+
+class CertConfirmContent(univ.SequenceOf):
+    """Defines the ASN.1 structure for the `CertConfirmContent`."""
+
+    componentType = CertStatus()
+
+
 # The challenge change, so that the PKIBody needs to be overwritten.
 # So the only difference is the `popdecc: POPODecKeyChallContentAsn1`
 # body. The rest is the same as the `PKIBody` class.
@@ -317,7 +337,7 @@ class PKIBodyTMP(univ.Choice):
         ),
         namedtype.NamedType(
             "certConf",
-            rfc9480.CertConfirmContent().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 24)),
+            CertConfirmContent().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 24)),
         ),
         namedtype.NamedType(
             "pollReq",

--- a/resources/ca_ra_utils.py
+++ b/resources/ca_ra_utils.py
@@ -54,7 +54,14 @@ from resources import (
     protectionutils,
     utils,
 )
-from resources.asn1_structures import CertResponseTMP, ChallengeASN1, PKIBodyTMP, PKIMessageTMP
+from resources.asn1_structures import (
+    CertConfirmContent,
+    CertResponseTMP,
+    CertStatus,
+    ChallengeASN1,
+    PKIBodyTMP,
+    PKIMessageTMP,
+)
 from resources.asn1utils import get_set_bitstring_names, try_decode_pyasn1
 from resources.certextractutils import get_extension
 from resources.convertutils import (
@@ -3135,7 +3142,7 @@ def _validate_cert_status(
 
 
 def _process_cert_hash_alg(
-    entry: rfc9480.CertStatus,
+    entry: CertStatus,
     pvno: int,
     issued_cert: rfc9480.CMPCertificate,
     hash_alg: Optional[str] = None,
@@ -3225,7 +3232,7 @@ def build_pki_conf_from_cert_conf(  # noqa: D417 Missing argument descriptions i
     if request["body"].getName() != "certConf":
         raise ValueError("Request must be a `certConf` to build a `PKIConf` message from it.")
 
-    cert_conf: rfc9480.CertConfirmContent = request["body"]["certConf"]
+    cert_conf: CertConfirmContent = request["body"]["certConf"]
 
     if len(cert_conf) != 1 and enforce_lwcmp:
         raise BadRequest(f"Invalid number of entries in CertConf message.Expected 1 for LwCMP, got {len(cert_conf)}")
@@ -3233,7 +3240,7 @@ def build_pki_conf_from_cert_conf(  # noqa: D417 Missing argument descriptions i
     if len(cert_conf) != len(issued_certs):
         raise ValueError("Number of CertConf entries does not match the number of issued certificates.")
 
-    entry: rfc9480.CertStatus
+    entry: CertStatus
     hash_alg = kwargs.get("hash_alg")
     for entry, issued_cert in zip(cert_conf, issued_certs):
         if kwargs.get("was_p10cr"):

--- a/resources/cmputils.py
+++ b/resources/cmputils.py
@@ -49,7 +49,14 @@ from resources import (
     protectionutils,
     utils,
 )
-from resources.asn1_structures import CertProfileValueAsn1, KemCiphertextInfoAsn1, PKIMessagesTMP, PKIMessageTMP
+from resources.asn1_structures import (
+    CertConfirmContent,
+    CertProfileValueAsn1,
+    CertStatus,
+    KemCiphertextInfoAsn1,
+    PKIMessagesTMP,
+    PKIMessageTMP,
+)
 from resources.asn1utils import try_decode_pyasn1
 from resources.convertutils import copy_asn1_certificate, str_to_bytes
 from resources.exceptions import BadAsn1Data, BadCertTemplate, BadDataFormat, BadRequest
@@ -3034,7 +3041,7 @@ def prepare_certstatus(  # noqa D417 undocumented-param
     cert: Optional[rfc9480.CMPCertificate] = None,
     bad_cert_id: bool = False,
     different_hash: bool = False,
-) -> rfc9480.CertStatus:
+) -> CertStatus:
     """Prepare a `CertStatus` structure for a certificate confirmation `certConf` PKIMessage.
 
     Generates a CertStatus pyasn1 structure used in certificate confirmation messages to prove that the
@@ -3069,7 +3076,7 @@ def prepare_certstatus(  # noqa D417 undocumented-param
     | status=rejection | text=Certificate issued with modifications |
 
     """
-    cert_status = rfc9480.CertStatus()
+    cert_status = CertStatus()
 
     cert_status["certReqId"] = int(cert_req_id)
 
@@ -3107,16 +3114,16 @@ def prepare_certstatus(  # noqa D417 undocumented-param
     return cert_status
 
 
-def _prepare_cert_conf(cert_status: Union[List[rfc9480.CertStatus], rfc9480.CertStatus]) -> rfc9480.CertConfirmContent:
+def _prepare_cert_conf(cert_status: Union[List[CertStatus], CertStatus]) -> CertConfirmContent:
     """Create a `CertConfirmContent` structure for certificate confirmation.
 
     :param cert_status: A single or a list of `CertStatus` objects to include in the `CertConfirmContent` object.
     :return: A `CertConfirmContent` structure containing the certificate confirmation status(es).
     """
-    if isinstance(cert_status, rfc9480.CertStatus):
+    if isinstance(cert_status, CertStatus):
         cert_status = [cert_status]
 
-    cert_conf = rfc9480.CertConfirmContent().subtype(explicitTag=Tag(tagClassContext, tagFormatSimple, 24))
+    cert_conf = CertConfirmContent().subtype(explicitTag=Tag(tagClassContext, tagFormatSimple, 24))
     cert_conf.extend(cert_status)
     return cert_conf
 
@@ -3350,7 +3357,7 @@ def _process_single_cert_conf_cert(
     *,
     pvno: int = 2,
     hash_for_v3: bool = True,
-) -> rfc9480.CertStatus:
+) -> CertStatus:
     """Process a single certificate for `certConf` PKIMessage.
 
     :param tmp_cert: The certificate to process.
@@ -3413,7 +3420,7 @@ def build_cert_conf_from_resp(  # noqa D417 undocumented-param
     ca_message: PKIMessageTMP,
     recipient: str = "testr@example.com",
     sender: str = "tests@example.com",
-    cert_status: Union[rfc9480.CertStatus, List[rfc9480.CertStatus], None] = None,
+    cert_status: Union[CertStatus, List[CertStatus], None] = None,
     exclude_fields: Optional[str] = None,
     hash_alg: Optional[str] = None,
     cert_req_id: Optional[Strint] = None,
@@ -3548,7 +3555,7 @@ def build_cert_conf_from_resp(  # noqa D417 undocumented-param
             )
             cert_status_list.append(cert_status)
     else:
-        if isinstance(cert_status, rfc9480.CertStatus):
+        if isinstance(cert_status, CertStatus):
             cert_status = [cert_status]
 
         cert_status_list.extend(cert_status)
@@ -3582,7 +3589,7 @@ def build_cert_conf(  # noqa D417 undocumented-param
     exclude_fields: Optional[str] = None,
     hash_alg: Optional[str] = None,
     cert_hash: Optional[bytes] = None,
-    cert_status: Optional[rfc9480.CertStatus] = None,
+    cert_status: Optional[CertStatus] = None,
     status_info: Optional[rfc9480.PKIStatusInfo] = None,
     **params,
 ) -> PKIMessageTMP:

--- a/unit_tests/tests_build_messages/test_build_cert_conf_hash_alg.py
+++ b/unit_tests/tests_build_messages/test_build_cert_conf_hash_alg.py
@@ -7,7 +7,7 @@ import unittest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from pyasn1_alt_modules import rfc9480
 
-from resources.asn1_structures import PKIMessageTMP
+from resources.asn1_structures import PKIMessageTMP, CertStatus
 from resources.ca_ra_utils import build_ip_cmp_message, build_pki_conf_from_cert_conf
 from resources.certbuildutils import build_certificate
 from resources.cmputils import build_cert_conf_from_resp
@@ -41,7 +41,7 @@ class TestCertConfHashAlgByVersion(unittest.TestCase):
         ip_msg["extraCerts"].append(self.ca_cert)
         return ip_msg
 
-    def _first_cert_status(self, cert_conf_msg: PKIMessageTMP) -> rfc9480.CertStatus:
+    def _first_cert_status(self, cert_conf_msg: PKIMessageTMP) -> CertStatus:
         """Extract the first CertStatus from a CertConf message."""
         self.assertEqual(cert_conf_msg["body"].getName(), "certConf")
         content = cert_conf_msg["body"]["certConf"]

--- a/unit_tests/tests_prepare_cert_related_structures/test_prepare_cert_status.py
+++ b/unit_tests/tests_prepare_cert_related_structures/test_prepare_cert_status.py
@@ -8,6 +8,7 @@ from pyasn1.codec.der import decoder, encoder
 from pyasn1.type import univ
 from pyasn1_alt_modules import rfc9480
 from resources import oid_mapping
+from resources.asn1_structures import CertStatus
 from resources.cmputils import prepare_certstatus
 
 
@@ -32,7 +33,7 @@ class TestPrepareCertStatus(unittest.TestCase):
             cert_hash=self.cert_hash, cert_req_id=self.cert_req_id, status=self.valid_status
         )
         encoded_cert_status = encoder.encode(cert_status)
-        decoded_cert_status, rest = decoder.decode(encoded_cert_status, asn1Spec=rfc9480.CertStatus())
+        decoded_cert_status, rest = decoder.decode(encoded_cert_status, asn1Spec=CertStatus())
         self.assertEqual(rest, b"")
         self.assertEqual(decoded_cert_status["certHash"], univ.OctetString(self.cert_hash))
         self.assertEqual(decoded_cert_status["certReqId"], self.cert_req_id)
@@ -68,7 +69,7 @@ class TestPrepareCertStatus(unittest.TestCase):
             cert_hash=self.cert_hash, cert_req_id=self.cert_req_id, status=self.valid_status, hash_alg=self.hash_alg
         )
         encoded_cert_status = encoder.encode(cert_status)
-        decoded_cert_status, rest = decoder.decode(encoded_cert_status, asn1Spec=rfc9480.CertStatus())
+        decoded_cert_status, rest = decoder.decode(encoded_cert_status, asn1Spec=CertStatus())
         self.assertEqual(rest, b"")
         self.assertTrue(decoded_cert_status["hashAlg"].isValue)
         self.assertEqual(decoded_cert_status["hashAlg"]["algorithm"], oid_mapping.sha_alg_name_to_oid(self.hash_alg))
@@ -83,7 +84,7 @@ class TestPrepareCertStatus(unittest.TestCase):
             cert_hash=self.cert_hash, cert_req_id=self.cert_req_id, status=self.valid_status, hash_alg=None
         )
         encoded_cert_status = encoder.encode(cert_status)
-        decoded_cert_status, rest = decoder.decode(encoded_cert_status, asn1Spec=rfc9480.CertStatus())
+        decoded_cert_status, rest = decoder.decode(encoded_cert_status, asn1Spec=CertStatus())
         self.assertEqual(rest, b"")
         self.assertFalse(decoded_cert_status["hashAlg"].isValue)
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Fix the `CertStatus` structure.

## Description

- Redefine `CertStatus` and fixed imports.

## Motivation and Context

- Fix implementation.

## How Has This Been Tested?

- OpenSSL v.3.6.0
- - unit tests.
 
