### PR TITLE
Update Client Examples

### DIFF
--- a/MockCA_readme.md
+++ b/MockCA_readme.md
@@ -319,7 +319,7 @@ docker run --rm -it \
   --entrypoint python \
   ghcr.io/siemens/cmp-test \
   -m mock_ca.client request kem-cert \
-  --algorithm ml-kem-768 \
+  --algorithm composite-kem-ml-kem-768-ecdh-secp256r1\
   --url http://127.0.0.1:5000/issuing
 ```
 

--- a/MockCA_readme.md
+++ b/MockCA_readme.md
@@ -313,6 +313,16 @@ openssl cmp -cmd ir \
   -unprotected_errors
 ```
 
+```bash
+docker run --rm -it \
+  --network host \
+  --entrypoint python \
+  ghcr.io/siemens/cmp-test \
+  -m mock_ca.client request kem-cert \
+  --algorithm ml-kem-768 \
+  --url http://127.0.0.1:5000/issuing
+```
+
 ### Robot Framework Test
 
 ```sh

--- a/MockCA_readme.md
+++ b/MockCA_readme.md
@@ -202,6 +202,12 @@ in a second shell:
     make test env=mock_ca
 ```
 
+Or via the docker container:
+
+```sh
+  docker run --rm -it ghcr.io/siemens/cmp-test-base:latest --mockca 5000
+```
+
 #### Expected output
 
 You should see Flask startup output similar to:

--- a/mock_ca/ca_handler.py
+++ b/mock_ca/ca_handler.py
@@ -5,6 +5,7 @@
 """Contains the CA Handler for the Mock CA."""
 
 import argparse
+import base64
 import logging
 import os
 import sys
@@ -1491,6 +1492,13 @@ def handle_crl_request():
     return Response(data, content_type="application/pkix-crl")
 
 
+@app.route("/root-cert", methods=["GET"])
+def handle_root_cert():
+    """Return the Root CA certificate as Base64-encoded DER."""
+    der = asn1utils.encode_to_der(handler.ca_cert)
+    return Response(base64.b64encode(der), content_type="text/plain")
+
+
 @app.route("/cert/<serial_number>", methods=["GET"])
 def get_cert(serial_number):
     """Get the Sun-Hybrid certificate for the specified serial number."""
@@ -1749,13 +1757,7 @@ if __name__ == "__main__":
     )
     _register_routes(app)
 
-    # import ssl
-    # DOMAIN = "mydomain.com"
-    # CERT_DIR = f"/etc/letsencrypt/live/{DOMAIN}"
-    # CERT_FILE = os.path.join(CERT_DIR, "fullchain.pem")
-    # KEY_FILE = os.path.join(CERT_DIR, "privkey.pem")
-    # context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-    # context.load_cert_chain(certfile=CERT_FILE, keyfile=KEY_FILE)
-    # context = "adhoc"
-    # app.run(port=5000, debug=True, ssl_context=context)
+    root_cert_der = asn1utils.encode_to_der(handler.ca_cert)
+    print(f"Root CA certificate (Base64 DER): {base64.b64encode(root_cert_der).decode('ascii')}") # noqa: T201
+
     app.run(host=args.host, port=args.port, debug=True)

--- a/mock_ca/ca_handler.py
+++ b/mock_ca/ca_handler.py
@@ -263,6 +263,7 @@ class CAHandler:
         base_url: str = "http://127.0.0.1",
         enforce_rfc9481: bool = False,
         trusted_ras_dir: str = "./data/trusted_ras",
+        allow_same_key_cert_req: bool = False,
     ):
         """Initialize the CA Handler.
 
@@ -279,6 +280,8 @@ class CAHandler:
         :param enforce_rfc9481: Whether to enforce the RFC 9481 algorithm profile,
         for MAC and traditional protected PKIMessages. Defaults to `False`.
         :param trusted_ras_dir: The directory for the trusted RAs. Defaults to `./data/trusted_ras`.
+        :param allow_same_key_cert_req: Whether to allow re-issuing a certificate with the same
+            public key for the same CN (ir/cr/p10cr/ccr). Defaults to `False`.
         :raises BadConfig: If the CA certificate and key are not provided.
         """
         if ca_cert is None and ca_key is None:
@@ -417,6 +420,7 @@ class CAHandler:
             cmp_protection_cert=self.protection_handler.protection_cert,
             pq_stateful_sig_state=self.pq_stateful_sig_state,
             ca_cert_chain=self.ca_cert_chain,
+            allow_same_key_cert_req=allow_same_key_cert_req,
         )
 
         self.stfl_validator = STFLPKIMessageValidator(
@@ -1727,9 +1731,22 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Mock CA server")
     parser.add_argument("--host", type=str, default="127.0.0.1", help="The host address, is set to 0.0.0.0 for docker.")
     parser.add_argument("--port", type=int, default=5000, help="The port to run the server on.")
+    parser.add_argument(
+        "--allow-same-key",
+        action="store_true",
+        default=False,
+        help="Allow re-issuing a certificate with the same public key for the same CN (ir/cr/p10cr/ccr).",
+    )
 
     args = parser.parse_args()
-    handler = CAHandler(ca_cert=None, ca_key=None, config={}, mock_ca_state=state, port=args.port)
+    handler = CAHandler(
+        ca_cert=None,
+        ca_key=None,
+        config={},
+        mock_ca_state=state,
+        port=args.port,
+        allow_same_key_cert_req=args.allow_same_key,
+    )
     _register_routes(app)
 
     # import ssl

--- a/mock_ca/ca_handler.py
+++ b/mock_ca/ca_handler.py
@@ -280,7 +280,7 @@ class CAHandler:
         :param enforce_rfc9481: Whether to enforce the RFC 9481 algorithm profile,
         for MAC and traditional protected PKIMessages. Defaults to `False`.
         :param trusted_ras_dir: The directory for the trusted RAs. Defaults to `./data/trusted_ras`.
-        :param allow_same_key_cert_req: Whether to allow re-issuing a certificate with the same
+        :param allow_same_key_cert_req: Whether to allow issuing a certificate with the same
             public key for the same CN (ir/cr/p10cr/ccr). Defaults to `False`.
         :raises BadConfig: If the CA certificate and key are not provided.
         """

--- a/mock_ca/cert_req_handler.py
+++ b/mock_ca/cert_req_handler.py
@@ -108,6 +108,7 @@ class CertReqHandler:
         pq_stateful_sig_state: Optional[StatefulSigState] = None,
         stfl_validator: Optional[STFLPKIMessageValidator] = None,
         ca_cert_chain: Optional[List[rfc9480.CMPCertificate]] = None,
+        allow_same_key_cert_req: bool = False,
     ):
         """Initialize the certificate request handler.
 
@@ -124,6 +125,8 @@ class CertReqHandler:
         :param pq_stateful_sig_state: The state for post-quantum stateful signatures.
         :param stfl_validator: The validator for the pqc-stateful (e.g., HSS, XMSS) PKIMessage.
         :param ca_cert_chain: The certificate chain for the CA certificate.
+        :param allow_same_key_cert_req: Whether to allow re-issuing a certificate with the same
+            public key for the same CN (ir/cr/p10cr/ccr). Defaults to `False`.
         """
         self.ca_cert = ca_cert
         self._ca_cert_chain = ca_cert_chain or [self.ca_cert]
@@ -142,7 +145,7 @@ class CertReqHandler:
         self.must_be_protected = True
         self.check_time = True
         self.allowed_interval = 500
-        self.allow_same_key_cert_req = False
+        self.allow_same_key_cert_req = allow_same_key_cert_req
         self.allow_same_key_kur = False
         self.sender = "CN=Mock-CA"
         self.kga_key = kga_key

--- a/mock_ca/client.py
+++ b/mock_ca/client.py
@@ -155,21 +155,21 @@ def build_example_revoked_cert(
     return cert_chain, key
 
 
-def _check_response(response: Optional[PKIMessageTMP], for_pkiconf: bool) -> bool:
+def _check_response(response: Optional[PKIMessageTMP], for_pkiconf: bool) -> PKIMessageTMP | None:
     if response is None:
         print("Failed to receive a response from the server.")
-        return False
+        return None
     if for_pkiconf:
         if get_cmp_message_type(response) != "pkiconf":
             print("Expected pkiconf response, but got a different message type.")
             print(display_pki_status_info(response))
-            return False
+            return None
     else:
         if get_status_from_pkimessage(response) != "accepted":
             print("Request was not accepted by the server.")
             print(display_pki_status_info(response))
-            return False
-    return True
+            return None
+    return response
 
 
 def build_kem_cert_request(
@@ -188,7 +188,9 @@ def build_kem_cert_request(
     :param url: The URL of the Mock CA server.
     :return: The response PKIMessage from the server, or None if the request failed.
     """
-    key = keyutils.generate_key(algorithm, by_name=True)
+    key = keyutils.generate_key(algorithm, by_name=True) # type: ignore
+    key: KEMPrivateKey
+
 
     pki_message = cmputils.build_cr_from_key(
         key,
@@ -205,7 +207,8 @@ def build_kem_cert_request(
     )
 
     response = send_pkimessage_to_mock_ca(pki_message=protected_cr, url=url, verify=False)
-    if not _check_response(response, for_pkiconf=False):
+    response = _check_response(response, for_pkiconf=False)
+    if response is None:
         return None
 
     kem_cert = get_enc_cert_from_pkimessage(response, ee_private_key=key, exclude_rid_check=True)
@@ -223,7 +226,8 @@ def build_kem_cert_request(
         password="SiemensIT",
     )
     response_pkiconf = send_pkimessage_to_mock_ca(pki_message=protected_cert, url=url, verify=False)
-    if not _check_response(response_pkiconf, for_pkiconf=True):
+    response_pkiconf =  _check_response(response_pkiconf, for_pkiconf=True)
+    if response_pkiconf is None:
         return None
 
     return build_cmp_chain_from_pkimessage(response, kem_cert), key

--- a/mock_ca/client.py
+++ b/mock_ca/client.py
@@ -290,7 +290,7 @@ def main() -> int:
         if response is not None:
             save_key(response[1], f"{args.algorithm}_private_key.pem", password=None)
             cert_chain = response[0]
-            pem_certs = "\n".join([pyasn1_cert_to_pem(cert_chain[i]) for i in range(len(cert_chain))])
+            pem_certs = "".join([pyasn1_cert_to_pem(cert_chain[i]) for i in range(len(cert_chain))])
             print(pem_certs)
             write_cmp_certificate_to_pem(cert_chain[0], f"{args.algorithm}_cert_chain.pem")
             return 0

--- a/mock_ca/client.py
+++ b/mock_ca/client.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Client to send requests to the Mock CA."""
 
+import argparse
 import logging
 import sys
 import time
@@ -145,5 +146,67 @@ def build_example_revoked_cert(
     return cert_chain, key
 
 
+def _prepare_parser() -> argparse.ArgumentParser:
+    """Prepare the argument parser for the CLI."""
+    parser = argparse.ArgumentParser(
+        description="CMP Test Suite Mock CA Client",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True, help="Available commands")
+
+    request_parser = subparsers.add_parser(
+        "request",
+        help="Send requests to the Mock CA",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    request_subparsers = request_parser.add_subparsers(dest="request_type", required=True, help="Request types")
+
+    kem_cert_parser = request_subparsers.add_parser(
+        "kem-cert",
+        help=(
+            "Request a KEM-based certificate using password-based MAC protection. "
+            "Supports ml-kem-768 (pure PQ) and composite-kem with SecP256r1MLKEM768 "
+            "(composite-kem-ml-kem-768-ecdh-secp256r1)."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    kem_cert_parser.add_argument(
+        "--algorithm",
+        "-alg",
+        type=str,
+        default="ml-kem-768",
+        help=(
+            "KEM algorithm to use: ml-kem-768 (pure ML-KEM-768) or "
+            "composite-kem-ml-kem-768-ecdh-secp256r1 (SecP256r1MLKEM768 hybrid)."
+        ),
+    )
+    kem_cert_parser.add_argument(
+        "--url",
+        type=str,
+        default="http://127.0.0.1:5000/issuing",
+        help="URL of the Mock CA server.",
+    )
+    return parser
+
+
+def main() -> int:
+    """Main entry point for the CLI."""
+    parser = _prepare_parser()
+    args = parser.parse_args()
+
+    if args.command == "request" and args.request_type == "kem-cert":
+        response = build_kem_cert_request(
+            algorithm=args.algorithm,
+            url=args.url,
+        )
+        if response is not None:
+            print(response.prettyPrint())
+            return 0
+        return 1
+
+    return 0
+
+
 if __name__ == "__main__":
-    send_request_to_static_cert1()
+    sys.exit(main())

--- a/mock_ca/client.py
+++ b/mock_ca/client.py
@@ -15,14 +15,23 @@ from pyasn1_alt_modules import rfc9480
 
 sys.path.append(".")
 
+from pq_logic.keys.abstract_wrapper_keys import KEMPrivateKey
 from resources import cmputils, keyutils, protectionutils
 from resources.asn1_structures import PKIMessageTMP
 from resources.certutils import build_cmp_chain_from_pkimessage
-from resources.cmputils import build_cmp_revoke_request, parse_pkimessage
+from resources.cmputils import (
+    build_cert_conf_from_resp,
+    build_cmp_revoke_request,
+    get_cmp_message_type,
+    get_status_from_pkimessage,
+    parse_pkimessage,
+)
 from resources.convertutils import ensure_is_sign_key
+from resources.extra_issuing_logic import get_enc_cert_from_pkimessage
+from resources.keyutils import save_key
 from resources.protectionutils import protect_pkimessage
 from resources.typingutils import SignKey
-from resources.utils import display_pki_status_info
+from resources.utils import display_pki_status_info, pyasn1_cert_to_pem, write_cmp_certificate_to_pem
 
 
 def send_request_to_static_cert1() -> None:
@@ -146,10 +155,27 @@ def build_example_revoked_cert(
     return cert_chain, key
 
 
+def _check_response(response: Optional[PKIMessageTMP], for_pkiconf: bool) -> bool:
+    if response is None:
+        print("Failed to receive a response from the server.")
+        return False
+    if for_pkiconf:
+        if get_cmp_message_type(response) != "pkiconf":
+            print("Expected pkiconf response, but got a different message type.")
+            print(display_pki_status_info(response))
+            return False
+    else:
+        if get_status_from_pkimessage(response) != "accepted":
+            print("Request was not accepted by the server.")
+            print(display_pki_status_info(response))
+            return False
+    return True
+
+
 def build_kem_cert_request(
     algorithm: str = "ml-kem-768",
     url: str = "http://127.0.0.1:5000/issuing",
-) -> Optional[PKIMessageTMP]:
+) -> Optional[Tuple[list[rfc9480.CMPCertificate], KEMPrivateKey]]:
     """Build and send a KEM certificate request to the Mock CA using password-based MAC protection.
 
     Supports pure PQ KEM (ml-kem-768) and composite KEM
@@ -170,7 +196,6 @@ def build_kem_cert_request(
         sender="CN=Hans The Tester",
         sender_kid=b"CN=Hans The Tester",
         for_mac=True,
-        implicit_confirm=True,
     )
 
     protected_cr = protectionutils.protect_pkimessage(
@@ -179,7 +204,29 @@ def build_kem_cert_request(
         password="SiemensIT",
     )
 
-    return send_pkimessage_to_mock_ca(pki_message=protected_cr, url=url, verify=False)
+    response = send_pkimessage_to_mock_ca(pki_message=protected_cr, url=url, verify=False)
+    if not _check_response(response, for_pkiconf=False):
+        return None
+
+    kem_cert = get_enc_cert_from_pkimessage(response, ee_private_key=key, exclude_rid_check=True)
+
+    cert_conf = build_cert_conf_from_resp(
+        response,
+        cert=kem_cert,
+        for_mac=True,
+        sender="CN=Hans The Tester",
+        sender_kid=b"CN=Hans The Tester",
+    )
+    protected_cert = protectionutils.protect_pkimessage(
+        cert_conf,
+        protection="password_based_mac",
+        password="SiemensIT",
+    )
+    response_pkiconf = send_pkimessage_to_mock_ca(pki_message=protected_cert, url=url, verify=False)
+    if not _check_response(response_pkiconf, for_pkiconf=True):
+        return None
+
+    return build_cmp_chain_from_pkimessage(response, kem_cert), key
 
 
 def _prepare_parser() -> argparse.ArgumentParser:
@@ -237,8 +284,13 @@ def main() -> int:
             url=args.url,
         )
         if response is not None:
-            print(response.prettyPrint())
+            save_key(response[1], f"{args.algorithm}_private_key.pem", password=None)
+            cert_chain = response[0]
+            pem_certs = "\n".join([pyasn1_cert_to_pem(cert_chain[i]) for i in range(len(cert_chain))])
+            print(pem_certs)
+            write_cmp_certificate_to_pem(cert_chain[0], f"{args.algorithm}_cert_chain.pem")
             return 0
+
         return 1
 
     return 0

--- a/mock_ca/client.py
+++ b/mock_ca/client.py
@@ -13,16 +13,16 @@ import requests
 from pyasn1.codec.der import decoder, encoder
 from pyasn1_alt_modules import rfc9480
 
+sys.path.append(".")
+
+from resources import cmputils, keyutils, protectionutils
+from resources.asn1_structures import PKIMessageTMP
 from resources.certutils import build_cmp_chain_from_pkimessage
+from resources.cmputils import build_cmp_revoke_request, parse_pkimessage
 from resources.convertutils import ensure_is_sign_key
 from resources.protectionutils import protect_pkimessage
 from resources.typingutils import SignKey
 from resources.utils import display_pki_status_info
-
-sys.path.append(".")
-from resources import cmputils, keyutils, protectionutils
-from resources.asn1_structures import PKIMessageTMP
-from resources.cmputils import build_cmp_revoke_request, parse_pkimessage
 
 
 def send_request_to_static_cert1() -> None:
@@ -144,6 +144,42 @@ def build_example_revoked_cert(
         raise ValueError("No response received from the server.")
     time.sleep(3)
     return cert_chain, key
+
+
+def build_kem_cert_request(
+    algorithm: str = "ml-kem-768",
+    url: str = "http://127.0.0.1:5000/issuing",
+) -> Optional[PKIMessageTMP]:
+    """Build and send a KEM certificate request to the Mock CA using password-based MAC protection.
+
+    Supports pure PQ KEM (ml-kem-768) and composite KEM
+    (composite-kem-ml-kem-768-ecdh-secp256r1 / SecP256r1MLKEM768) as an example.
+
+    :param algorithm: The KEM algorithm to use. Valid options:
+        - ``"ml-kem-768"``: Pure ML-KEM-768 (Post-Quantum).
+        - ``"composite-kem-ml-kem-768-ecdh-secp256r1"``: Composite KEM SecP256r1MLKEM768
+          (hybrid: ML-KEM-768 + ECDH secp256r1 / P256).
+    :param url: The URL of the Mock CA server.
+    :return: The response PKIMessage from the server, or None if the request failed.
+    """
+    key = keyutils.generate_key(algorithm, by_name=True)
+
+    pki_message = cmputils.build_cr_from_key(
+        key,
+        common_name="CN=Hans The Tester",
+        sender="CN=Hans The Tester",
+        sender_kid=b"CN=Hans The Tester",
+        for_mac=True,
+        implicit_confirm=True,
+    )
+
+    protected_cr = protectionutils.protect_pkimessage(
+        pki_message,
+        protection="password_based_mac",
+        password="SiemensIT",
+    )
+
+    return send_pkimessage_to_mock_ca(pki_message=protected_cr, url=url, verify=False)
 
 
 def _prepare_parser() -> argparse.ArgumentParser:

--- a/mock_ca/client.py
+++ b/mock_ca/client.py
@@ -227,7 +227,7 @@ def _prepare_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
-    """Main entry point for the CLI."""
+    """Entry point for the CLI."""
     parser = _prepare_parser()
     args = parser.parse_args()
 

--- a/scripts/docker_entrypoint.py
+++ b/scripts/docker_entrypoint.py
@@ -72,11 +72,14 @@ def run_robot_command(command, verbose=False):
         return 1
 
 
-def start_mock_ca(port: int, verbose: bool) -> Optional[subprocess.CompletedProcess[bytes]]:
+def start_mock_ca(
+    port: int, verbose: bool, allow_same_key: bool = False
+) -> Optional[subprocess.CompletedProcess[bytes]]:
     """Start the Mock CA server with the provided port.
 
     :param port: The port to use for the Mock CA server.
     :param verbose: Whether to display additional information.
+    :param allow_same_key: Whether to allow re-issuing a certificate with the same public key.
     :return: The subprocess object if successful, None otherwise.
     """
     command = [
@@ -87,6 +90,8 @@ def start_mock_ca(port: int, verbose: bool) -> Optional[subprocess.CompletedProc
         "--port",
         str(port),
     ]
+    if allow_same_key:
+        command.append("--allow-same-key")
     if verbose:
         log.info("Starting Mock CA: %s", " ".join(command))
     try:
@@ -175,6 +180,13 @@ def prepare_parser():
         default=False,
     )
     parser.add_argument(
+        "--allow-the-same-key",
+        help="Allow the Mock CA to re-issue a certificate with the same public key (for testing purposes)",
+        action="store_true",
+        default=False,
+        dest="allow_the_same_key",
+    )
+    parser.add_argument(
         "--verbose", help="Display additional debugging information", action="store_true", default=False
     )
 
@@ -226,7 +238,7 @@ def main():
         log.debug(args)
 
     if args.mockca is not None:
-        result = start_mock_ca(args.mockca, args.verbose)
+        result = start_mock_ca(args.mockca, args.verbose, args.allow_the_same_key)
         if result is None:
             sys.exit(1)
         return


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Add allow-same-key support, KEM client CLI, and Docker usage docs

## Description

Improved the setup and examples to use the `Siemens` image for easier setup and quicker testing.

## Motivation and Context

- The `allow_same_key_cert_req` flag was hard-coded to `False` in
`CertReqHandler`, making it impossible to test certificate re-issuance
with the same public key without modifying source code. 

- Have a KEM example for quick issuing of example certs.

- Updated `MockCA_readme.md`: Easier docker usage for the client example and setup for running the `Siemens` MockCA image.

## How Has This Been Tested?

- Ran `python -m mock_ca.client request kem-cert --algorithm ml-kem-768` against
  a locally running Mock CA and verified a successful `cp` response.
- Ran the client example against a newly remotely build docker image.
