### PR TITLE
Bump Dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo  '  autoformat   - Run ruff on all the source files, to resolve all issues automatically '
 	@echo  '  verify  - Run a bunch of checks, to see if there are any obvious deficiencies in the code '
 	@echo  '  verifyformat   -  Check formatting only '
+	@echo  '  show-outdated - Show outdated packages (depth 1)'
 	@echo  '  start-mock-ca   -  Start the mock CA server, so that it can listens to requests '
 	@echo  '  test-mock-ca   -  Run the test against the mock CA server '
 	@echo  '  test-mock-ca-verbose   -  Run all tests against the mock CA server '
@@ -103,6 +104,9 @@ verify:
 
 verifyformat:
 	ruff check .
+
+show-outdated:
+	uv tree --outdated --depth 1
 
 dryrun:
 	robot --dryrun --pythonpath=./ --variable environment:$(env) tests tests_pq_and_hybrid  tests_mock_ca

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,15 @@ version = "0.0.2"
 description = "CMP Protocol Compliance Test Suite"
 requires-python = ">=3.13"
 dependencies = [
-    "cryptography==46.0.5",
-    "pyasn1==0.6.2",
+    "cryptography==46.0.7",
+    "pyasn1==0.6.3",
     "pyasn1-alt-modules==0.4.9",
     "robotframework==7.4.2",
     "pkilint==0.13.2",
     "robotframework-requests==0.9.7",
     "pycryptodome==3.23.0",
     "tinyec==0.4.0",
-    "bitstring==4.3.1",
+    "bitstring==4.4.0",
     "pyhsslms==2.0.0",
     # relevant for the Mock-CA.
     "Flask==3.1.3",
@@ -27,8 +27,8 @@ dependencies = [
 dev = [
     "safety>=3.7.0,<4.0.0",
     "pylint>=4.0.4,<5.0.0",
-    "ruff>=0.15.5,<1.0.0",
-    "robotframework-robocop==8.2.2",
+    "ruff>=0.15.9,<1.0.0",
+    "robotframework-robocop==8.2.5",
     "pyright[nodejs]==1.1.408",
     "codespell==2.4.2",
     "reuse==6.2.0",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Add new makefile command to quickly check the outdated packages and bump the dependency versions.

## Description

- `cryptography`: `46.0.5` -> `46.0.7`
- `pyasn1`: `0.6.2` -> `0.6.3`
- `bitstring`: `4.3.1` -> `4.4.0`
- changed `ruff` minimum version from `0.15.5` -> `0.15.9`
- `robotframework-robocop`: `8.2.2` -> `8.2.5`

## Motivation and Context

- newer dependencies.

## How Has This Been Tested?

- unit tests