### PR TITLE
Fix(DateTime): Ensure all date conversions consistently truncate microseconds

### DIFF
--- a/pq_logic/hybrid_sig/cert_binding_for_multi_auth.py
+++ b/pq_logic/hybrid_sig/cert_binding_for_multi_auth.py
@@ -15,7 +15,7 @@ https://datatracker.ietf.org/doc/draft-ietf-lamps-cert-binding-for-multi-auth/
 import email
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from cryptography import x509
@@ -612,7 +612,7 @@ def server_side_validate_cert_binding_for_multi_auth(ee_cert, related_cert) -> N
     # SHOULD determine that all certificates are valid at the time of issuance.
     # The usable overlap of validity periods is a Subscriber concern.
 
-    now = datetime.now()
+    now = datetime.now(timezone.utc).replace(microsecond=0)
 
     val_cert_a = related_cert["tbsCertificate"]["validity"]
     cert_b = ee_cert["tbsCertificate"]["validity"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "CMP Protocol Compliance Test Suite"
 requires-python = ">=3.13"
 dependencies = [
     "cryptography==46.0.7",
-    "pyasn1==0.6.2",
+    "pyasn1==0.6.3",
     "pyasn1-alt-modules==0.4.9",
     "robotframework==7.4.2",
     "pkilint==0.13.2",

--- a/resources/cmputils.py
+++ b/resources/cmputils.py
@@ -234,8 +234,7 @@ def prepare_pki_message(
         if message_time is None:
             # the date is not correctly converted, so that it could happen for test cases,
             # that the messageTime is in the future. So a slightly older time is used
-            date_time = datetime.now(timezone.utc) - timedelta(seconds=3)
-            message_time = prepareutils.prepare_generalized_time(date_time)
+            message_time = datetime.now(timezone.utc) - timedelta(seconds=3)
 
         msg_time_obj = prepareutils.convert_to_generalized_time(
             message_time,

--- a/resources/cmputils.py
+++ b/resources/cmputils.py
@@ -235,7 +235,7 @@ def prepare_pki_message(
             # the date is not correctly converted, so that it could happen for test cases,
             # that the messageTime is in the future. So a slightly older time is used
             date_time = datetime.now(timezone.utc) - timedelta(seconds=3)
-            message_time = useful.GeneralizedTime().fromDateTime(date_time)
+            message_time = prepareutils.prepare_generalized_time(date_time)
 
         msg_time_obj = prepareutils.convert_to_generalized_time(
             message_time,

--- a/resources/cmputils.py
+++ b/resources/cmputils.py
@@ -183,7 +183,7 @@ def prepare_pki_message(
     implicit_confirm: bool = False,
     recip_kid: Optional[bytes] = None,
     sender_kid: Optional[bytes] = None,
-    message_time: Optional[useful.GeneralizedTime] = None,
+    message_time: Optional[Union[useful.GeneralizedTime, datetime]] = None,
     pki_free_text: Optional[Union[List[str], str]] = None,
     pvno: Optional[Strint] = 2,
     **kwargs,

--- a/resources/cmputils.py
+++ b/resources/cmputils.py
@@ -4134,9 +4134,9 @@ def _prepare_generalinfo(
         new_time = datetime.now(timezone.utc)
         new_time = new_time + timedelta(seconds=int(confirm_wait_time))
         if negative_value:
-            new_time = useful.UTCTime().fromDateTime(new_time)
+            new_time = prepareutils.prepare_utc_time(new_time)
         else:
-            new_time = useful.GeneralizedTime().fromDateTime(new_time)
+            new_time = prepareutils.prepare_generalized_time(new_time)
 
         confirm_wait_time_obj["infoValue"] = new_time
         general_info_wrapper.append(confirm_wait_time_obj)

--- a/resources/general_msg_utils.py
+++ b/resources/general_msg_utils.py
@@ -555,7 +555,7 @@ def _prepare_time_for_crl_update_retrieval(negative: bool, crl_filepath: Union[s
     :return: A `rfc9480.Time` object populated with the calculated `thisUpdate` time.
     """
     if crl_filepath is None:
-        dt_object = datetime.datetime.now()
+        dt_object = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
     else:
         crl_object = utils.load_crl_from_file(crl_filepath)
         last_update = crl_object["tbsCertList"]["thisUpdate"]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Fix datetime parsing and creation.

## Description

- Remove microseconds.
- Update `pyasn1` to version `6.0.3`


## Motivation and Context

- Correct implementation.
- Align with `pyasn1` version 6.0.3

## How Has This Been Tested?

- unit tests (locally and pipeline)
 
