### PR TITLE
docs(MockCA): Fix MockCA doc

### DIFF
--- a/MockCA_readme.md
+++ b/MockCA_readme.md
@@ -205,7 +205,7 @@ in a second shell:
 Or via the docker container:
 
 ```sh
-  docker run --rm -it ghcr.io/siemens/cmp-test-base:latest --mockca 5000
+  docker run --rm -it ghcr.io/siemens/cmp-test:latest --mockca 5000
 ```
 
 #### Expected output

--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,12 @@ Run tests against it (in a new shell):
    make test env=mock_ca
 ```
 
+Or via the docker container:
+
+```sh
+  docker run --rm -it ghcr.io/siemens/cmp-test:latest --mockca 5000
+```
+
 # Acknowledgments
 The development of the CMP test suite was partly funded by the German Federal Ministry of Education and Research
 in the project Quoryptan through grant number 16KIS2033.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Updates the documentation to clarify how to start the mock CA server using Docker. 

## Description

* Added instructions to `readme.md` on how to start the mock CA server using the `ghcr.io/siemens/cmp-test:latest` Docker image.
* Updated the Docker image reference in `MockCA_readme.md` from `cmp-test-base:latest` to `cmp-test:latest` for consistency

## Motivation and Context

- Fix docs.
- Easier to find the command.


## How Has This Been Tested?

- Run the container.
