### PR TITLE
Update Dependencies

### DIFF
--- a/pq_logic/combined_factory.py
+++ b/pq_logic/combined_factory.py
@@ -343,7 +343,7 @@ class CombinedKeyFactory:
         raise BadAlg(f"Unsupported hybrid key OID: {oid}")
 
     @staticmethod
-    def load_public_key_from_spki(spki: Union[rfc5280.SubjectPublicKeyInfo, bytes]):  # type: ignore
+    def load_public_key_from_spki(spki: Union[rfc5280.SubjectPublicKeyInfo, bytes]) -> PublicKey:  # type: ignore
         """Load a public key from an SPKI structure.
 
         :param spki: rfc5280.SubjectPublicKeyInfo structure.
@@ -371,7 +371,7 @@ class CombinedKeyFactory:
         if oid == id_rsa_kem_spki:
             return RSAEncapKey.from_spki(spki)
 
-        return serialization.load_der_public_key(encoder.encode(spki))
+        return serialization.load_der_public_key(encoder.encode(spki))# type: ignore
 
     @staticmethod
     def supported_algorithms():
@@ -610,7 +610,7 @@ class CombinedKeyFactory:
             return XWingPrivateKey.from_seed(seed)
 
         if algorithm == "rsa":
-            return serialization.load_der_private_key(seed, password=None)
+            return serialization.load_der_private_key(seed, password=None) # type: ignore
 
         if algorithm == "rsa-kem":
             key = serialization.load_der_private_key(seed, password=None)
@@ -1013,7 +1013,7 @@ class CombinedKeyFactory:
         return public_key
 
 
-def _load_traditional_ecc_private_key(name: str, private_data: bytes, curve: Optional[str] = None):
+def _load_traditional_ecc_private_key(name: str, private_data: bytes, curve: Optional[str] = None) -> PrivateKey:
     """Load a traditional private key from the given private key data."""
     if name in ["x25519", "x448", "ecdh"]:
         tmp_key = DHKEMPrivateKey.from_private_bytes(name, private_data, curve=curve)
@@ -1023,4 +1023,4 @@ def _load_traditional_ecc_private_key(name: str, private_data: bytes, curve: Opt
     if name == "ed448":
         return Ed448PrivateKey.from_private_bytes(private_data)
 
-    return serialization.load_der_private_key(private_data, password=None)
+    return serialization.load_der_private_key(private_data, password=None) # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ version = "0.0.2"
 description = "CMP Protocol Compliance Test Suite"
 requires-python = ">=3.13"
 dependencies = [
-    "cryptography==46.0.7",
+    "cryptography==48.0.0",
     "pyasn1==0.6.3",
     "pyasn1-alt-modules==0.4.10",
     "robotframework==7.4.2",
-    "pkilint==0.13.2",
+    "pkilint==0.13.3",
     "robotframework-requests==0.9.7",
     "pycryptodome==3.23.0",
     "tinyec==0.4.0",
@@ -27,9 +27,9 @@ dependencies = [
 dev = [
     "safety>=3.7.0,<4.0.0",
     "pylint>=4.0.4,<5.0.0",
-    "ruff>=0.15.10,<1.0.0",
-    "robotframework-robocop==8.2.6",
-    "pyright[nodejs]==1.1.408",
+    "ruff>=0.15.12,<1.0.0",
+    "robotframework-robocop==8.2.7",
+    "pyright[nodejs]==1.1.409",
     "codespell==2.4.2",
     "reuse==6.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ dev = [
     "safety>=3.7.0,<4.0.0",
     "pylint>=4.0.4,<5.0.0",
     "ruff>=0.15.12,<1.0.0",
-    "robotframework-robocop==8.2.7",
-    "pyright[nodejs]==1.1.409",
+    "robotframework-robocop==8.2.11",
+    "pyright[nodejs]==1.1.410",
     "codespell==2.4.2",
     "reuse==6.2.0",
 ]

--- a/resources/keyutils.py
+++ b/resources/keyutils.py
@@ -497,7 +497,7 @@ def load_private_key_from_file(  # noqa: D417 for RF docs
         pem_data,
         password=password,  # type: ignore
     )
-    return private_key
+    return private_key  # type: ignore
 
 
 def load_public_key_from_file(filepath: str) -> PublicKey:  # noqa: D417 for RF docs
@@ -564,7 +564,7 @@ def load_public_key_from_spki(data: Union[bytes, rfc5280.SubjectPublicKeyInfo]) 
         if rest != b"":
             raise BadAsn1Data("SubjectPublicKeyInfo")
 
-    return pq_logic.combined_factory.CombinedKeyFactory.load_public_key_from_spki(spki=data)
+    return pq_logic.combined_factory.CombinedKeyFactory.load_public_key_from_spki(spki=data)  # type: ignore
 
 
 @not_keyword


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright 2024 Siemens AG

SPDX-License-Identifier: Apache-2.0
-->

Bump development dependencies and runtime dependency versions.

## Description
This PR updates development and runtime dependencies to their latest releases.

This PR updates development and runtime dependencies:
- `ruff` minimum version: `0.15.10` -> `0.15.12`
- `robotframework-robocop`: `8.2.6` -> `8.2.7`
- `pyright[nodejs]`: `1.1.408` -> `1.1.409`
- `cryptography`: `46.0.7` -> `48.0.0`
- `pkilint`: `0.13.2` -> `0.13.3`

## Motivation and Context
Routine maintenance to keep runtime and development tooling current and aligned with recent package releases. The `pyright` bump surfaced new diagnostics in the key-loading helpers, so missing type hints and targeted `type: ignore` comments were added in `pq_logic/combined_factory.py` and `resources/keyutils.py` to keep the type check clean.

## How Has This Been Tested?
- `ruff check .`
- `pyright`
- `python3 -m unittest discover -s unit_tests`
